### PR TITLE
LUT-31833 refresh frame content when selecting a swagger file

### DIFF
--- a/webapp/WEB-INF/templates/skin/plugins/swaggerui/swaggeriframe.html
+++ b/webapp/WEB-INF/templates/skin/plugins/swaggerui/swaggeriframe.html
@@ -46,59 +46,63 @@
 
   
   <script type="text/javascript">
-      var url;
+      let url;
       
       function loadSwaggerFile( selected ){
           url = selected;
-      };
-    $(function () {
-        
-      
-      hljs.configure({
-        highlightSizeThreshold: 5000
-      });
-
-      // Pre load translate...
-      if(window.SwaggerTranslator) {
-        window.SwaggerTranslator.translate();
+          initSwaggerUI();
       }
-      window.swaggerUi = new SwaggerUi({
-        url: url,
-        dom_id: "swagger-ui-container",
-        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
-        onComplete: function(swaggerApi, swaggerUi){
-          if(typeof initOAuth == "function") {
-            initOAuth({
-              clientId: "your-client-id",
-              clientSecret: "your-client-secret-if-required",
-              realm: "your-realms",
-              appName: "your-app-name",
-              scopeSeparator: " ",
-              additionalQueryStringParams: {}
-            });
-          }
 
+      function initSwaggerUI(){
+          hljs.configure({
+              highlightSizeThreshold: 5000
+          });
+
+          // Pre load translate...
           if(window.SwaggerTranslator) {
-            window.SwaggerTranslator.translate();
+              window.SwaggerTranslator.translate();
           }
-        },
-        onFailure: function(data) {
-          log("Unable to Load SwaggerUI");
-        },
-        docExpansion: "none",
-        jsonEditor: false,
-        defaultModelRendering: 'schema',
-        showRequestHeaders: false
-      });
+          window.swaggerUi = new SwaggerUi({
+              url: url,
+              dom_id: "swagger-ui-container",
+              supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+              onComplete: function(swaggerApi, swaggerUi){
+                  if(typeof initOAuth == "function") {
+                      initOAuth({
+                          clientId: "your-client-id",
+                          clientSecret: "your-client-secret-if-required",
+                          realm: "your-realms",
+                          appName: "your-app-name",
+                          scopeSeparator: " ",
+                          additionalQueryStringParams: {}
+                      });
+                  }
 
-      window.swaggerUi.load();
+                  if(window.SwaggerTranslator) {
+                      window.SwaggerTranslator.translate();
+                  }
+              },
+              onFailure: function(data) {
+                  log("Unable to Load SwaggerUI");
+              },
+              docExpansion: "none",
+              jsonEditor: false,
+              defaultModelRendering: 'schema',
+              showRequestHeaders: false
+          });
 
-      function log() {
-        if ('console' in window) {
-          console.log.apply(console, arguments);
-        }
+          window.swaggerUi.load();
+
+          function log() {
+              if ('console' in window) {
+                  console.log.apply(console, arguments);
+              }
+          }
       }
-  });
+
+    $(function () {
+        initSwaggerUI();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
Referenced by https://dev.lutece.paris.fr/bugtracker/issues/31833

When a new swagger file is selected from the selector,  nothing happens cause no event is triggered.
This PR fixes the event propagation.

<img width="772" height="206" alt="image" src="https://github.com/user-attachments/assets/95ffa7ee-1afb-4194-86df-a434ddaec2bb" />
